### PR TITLE
docs: update headers & make requirements more accurate

### DIFF
--- a/tasks/presentation.md
+++ b/tasks/presentation.md
@@ -1,7 +1,7 @@
-### Presentation
+## Presentation
 Your task is to prepare a presentation on a given topic (offered or approved by your mentor). The whole list of appropriate topics can be found [here](presentation-topics.md).
 
-Requirements:
+### Requirements:
 * 8 - 10 minutes for the presentation
 * Talk rehearsal within your subgroup is mandatory
 * Speaker notes for each slide are mandatory
@@ -11,7 +11,7 @@ Requirements:
 **Usage of https://slides.com/ is forbidden**
 
 ### Passing the task
-   1. Record your speech (reminder that it has to be in English) on your phone’s camera. Your face has to be in the shot, while the slides don't necessarily have to be in it. Here's a good example - https://www.youtube.com/watch?v=JezLAu4751Y&feature=youtu.be;
+   1. Record your speech (reminder that it has to be in English) on your **camera** (webcam, phone, video). Your **face has to be in the shot**, just like the **slides** if you can't edit your video in the video editing software (e.g. combine together the recording of slides and recording of your speech). Here's a good example - https://www.youtube.com/watch?v=JezLAu4751Y&feature=youtu.be;
   2. Upload the resulting video to your YouTube account. You can set the *unlisted* property for your video if you wish for no one else to see it(unless they get provided a link to the video);
   3. Add a link to your slides in the video description;
   4. Create a "presentation" branch in your private repository. Next up, create a markdown file named "presentation.md" and fill it with: 


### PR DESCRIPTION
- Requirements are so exact "phone's camera" (but, it don't necessarily must be the phone's camera: e.g. webcam, videocam);
- Requirements are different in the **Passing the task** & **Evaluation criteria** sections. According to the **Evaluation criteria** section, slides **MUST** be in the video, but they **SHOULD NOT** necessarily be recorded on the camera;
- Change header stylings (make Presentation header h2 & Requirements header h3);